### PR TITLE
Added brew openssl path to build.sh preflight and platform.mk CCFLAGS…

### DIFF
--- a/iRODS/config/platform.mk.template
+++ b/iRODS/config/platform.mk.template
@@ -180,6 +180,7 @@ endif
 
 # added by Ilari Korhonen (on osx build against openssl-1.0)
 ifeq ($(OS_platform), osx_platform)
+CCFLAGS+=-I/usr/local/opt/openssl/include/openssl
 LDADD+=-L/usr/local/opt/openssl/lib
 endif
 

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -958,7 +958,7 @@ else
     echo "Detected pam library [$PAMDEV]"
 fi
 
-OPENSSLDEV=`find /usr/include/openssl /opt/csw/include/openssl -name sha.h 2> /dev/null`
+OPENSSLDEV=`find /usr/include/openssl /opt/csw/include/openssl /usr/local/opt/openssl/include/openssl -name sha.h 2> /dev/null`
 if [ "$OPENSSLDEV" == "" ] ; then
     if [ "$DETECTEDOS" == "Ubuntu" -o "$DETECTEDOS" == "Debian" ] ; then
         PREFLIGHT="$PREFLIGHT libssl-dev"


### PR DESCRIPTION
…. Required for OSX El Capitan, which does not ship with openssl headers.
